### PR TITLE
Fix issue where chat history is saved redundantly

### DIFF
--- a/llmstack/play/actors/agent.py
+++ b/llmstack/play/actors/agent.py
@@ -89,7 +89,10 @@ class AgentActor(Actor):
         self._agent_messages = []
 
         if "chat_history_limit" in self._config and self._config["chat_history_limit"] > 0:
-            self._agent_messages += self._chat_history[-self._config["chat_history_limit"] :]  # noqa: E203
+            self._chat_history_limit = self._config["chat_history_limit"]
+            self._agent_messages += self._chat_history[-self._chat_history_limit :]  # noqa: E203
+        else:
+            self._chat_history_limit = 0
 
         self._agent_messages.append(
             {
@@ -305,7 +308,7 @@ class AgentActor(Actor):
                 )
                 # Persist session data
                 self._agent_app_session_data["data"] = {
-                    "chat_history": self._chat_history
+                    "chat_history": self._chat_history[: -self._chat_history_limit]
                     + self._agent_messages
                     + [{"role": "assistant", "content": full_content}],
                 }


### PR DESCRIPTION
This is to fix the following issue:

1. At initialization, AgentActor performs the following tasks:
   a.  Fills `self._chat_history` from `app_session_data`.
   b. Retrieves a list of conversations up to `self._config["chat_history_limit"]` from `self._chat_history`.
   c. Appends the last retrieved conversation list to `self._agent_messages` (ultimately used for openai chat completion).
2. Subsequently, when the openai client of AgentActor receives `finish_reason=stop`, it saves `chat_history` to `app_session_data` as `self._chat_history + self._agent_messages`. As a result, the conversation list obtained in **b** exists on both sides, leading to duplicate conversation storage.

To solve this issue, when saving `app_session_data`, modify it to exclude conversations up to `chat_history_limit` and save them to avoid unnecessary duplication.