### PR TITLE
feature(datasources): move datasource credentials to connections

### DIFF
--- a/llmstack/common/tests/blocks/data/store/database/test_database_reader.py
+++ b/llmstack/common/tests/blocks/data/store/database/test_database_reader.py
@@ -15,7 +15,7 @@ class MySQLReadTest(unittest.TestCase):
             user="root",
             password="",
             host="localhost",
-            port=5432,
+            port=3306,
             dbname="usersdb",
         )
         reader_input = DatabaseReaderInput(


### PR DESCRIPTION
## Goal

To Move SQL datasource credentials to connections.

## Changes

Modified the SQL datasource handler to allow selecting a connection when creating a datasource and retrieving the username and password from that connection when connecting to the database.

## Testing

Tested the end-to-end flow: Created a connection with basic authentication credentials, created a datasource using that connection, and queried the datasource in the playground.

## Reviewers

@ajhai and @vegito22
