### PR TITLE
hotfix(assets): change AssetsConfig.name from assets to llmstack.assets

### DIFF
--- a/llmstack/assets/apps.py
+++ b/llmstack/assets/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class AssetsConfig(AppConfig):
-    name = "assets"
+    name = "llmstack.assets"
     label = "assets"


### PR DESCRIPTION
## Goal

To resolve `AssetsConfig` name issue


```bash
(llmstack-py3.11) ➜  LLMStack git:(main) llmstack
Traceback (most recent call last):
  File "/opt/applications/trypromptly/LLMStack/.venv/lib/python3.11/site-packages/django/apps/config.py", line 210, in create
    app_module = import_module(app_name)
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'assets'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/applications/trypromptly/LLMStack/.venv/bin/llmstack", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/applications/trypromptly/LLMStack/llmstack/cli.py", line 306, in main
    run_django_command(["manage.py", "migrate", "--noinput"])
  File "/opt/applications/trypromptly/LLMStack/llmstack/cli.py", line 18, in run_django_command
    execute_from_command_line(command)
  File "/opt/applications/trypromptly/LLMStack/.venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/opt/applications/trypromptly/LLMStack/.venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
  File "/opt/applications/trypromptly/LLMStack/.venv/lib/python3.11/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/opt/applications/trypromptly/LLMStack/.venv/lib/python3.11/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/applications/trypromptly/LLMStack/.venv/lib/python3.11/site-packages/django/apps/config.py", line 212, in create
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Cannot import 'assets'. Check that 'llmstack.assets.apps.AssetsConfig.name' is correct.
(llmstack-py3.11) ➜  LLMStack git:(main) 

```

## Change

changed `AssetsConfig.name` from assets to `llmstack.assets`.

## Testing

Tested in local - The django development server should start without the above mentioned issue.

## Reviewers

@ajhai and @vegito22
