### PR TITLE
Feature/adhoc job scheduling

### DIFF
--- a/llmstack/client/src/components/schedule/AddAppRunScheduleModal.jsx
+++ b/llmstack/client/src/components/schedule/AddAppRunScheduleModal.jsx
@@ -14,6 +14,18 @@ import { axios } from "../../data/axios";
 import AddAppRunScheduleConfigForm from "./AddAppRunScheduleConfigForm";
 import InputDataTable from "./InputDataTable";
 
+function checkIfColumnFieldsAreSame(prevColumns, newColumns) {
+  if (prevColumns && newColumns && prevColumns.length === newColumns.length) {
+    for (let i = 0; i < prevColumns.length; i++) {
+      if (prevColumns[i].field !== newColumns[i].field) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 export default function AddAppRunScheduleModal(props) {
   const [columns, setColumns] = useState([]);
   const [configuration, setConfiguration] = useState({});
@@ -34,10 +46,18 @@ export default function AddAppRunScheduleModal(props) {
           };
         },
       );
-      setColumns(columnFields);
-      setAppRunData([]);
+
+      const hasSameColumnFields = checkIfColumnFieldsAreSame(
+        columns,
+        columnFields,
+      );
+
+      if (!hasSameColumnFields) {
+        setColumns(columnFields);
+        setAppRunData([]);
+      }
     }
-  }, [configuration]);
+  }, [configuration?.appDetail, columns]);
 
   return (
     <Dialog open={true} maxWidth="lg" fullWidth onClose={props.onClose}>

--- a/llmstack/client/src/components/schedule/FrequencyPickerWidget.jsx
+++ b/llmstack/client/src/components/schedule/FrequencyPickerWidget.jsx
@@ -34,6 +34,7 @@ export default function FrequencyPickerWidget(props) {
           variant="filled"
           sx={{ lineHeight: "0.5em" }}
         >
+          <MenuItem value="run_now">Run Now</MenuItem>
           <MenuItem value="run_once">Run Once</MenuItem>
           <MenuItem value="repeat">Repeat</MenuItem>
           <MenuItem value="cron">Cron Job</MenuItem>

--- a/llmstack/client/src/components/schedule/InputDataTable.jsx
+++ b/llmstack/client/src/components/schedule/InputDataTable.jsx
@@ -86,6 +86,7 @@ export default function InputDataTable({ columnData, rowData, onChange }) {
   const handleRowEditStop = (params, event) => {
     if (params.reason === GridRowEditStopReasons.rowFocusOut) {
       event.defaultMuiPrevented = true;
+      handleSaveClick(params.id)();
     }
   };
 

--- a/llmstack/jobs/apis.py
+++ b/llmstack/jobs/apis.py
@@ -334,7 +334,7 @@ class AppRunJobsViewSet(viewsets.ViewSet):
         if batch_size > len(data["app_run_data"]):
             return DRFResponse(status=400, data={"message": "Batch size cannot be greater than total rows"})
 
-        if frequency_type not in ["run_once", "repeat", "cron"]:
+        if frequency_type not in ["run_now", "run_once", "repeat", "cron"]:
             return DRFResponse(
                 status=400,
                 data={
@@ -343,7 +343,10 @@ class AppRunJobsViewSet(viewsets.ViewSet):
             )
 
         scheduled_time = None
-        if frequency_type == "run_once" or frequency_type == "repeat":
+        if frequency_type == "run_now":
+            scheduled_time = timezone.now()
+
+        elif frequency_type == "run_once" or frequency_type == "repeat":
             if (
                 not frequency.get("start_date")
                 or not frequency.get(
@@ -390,7 +393,12 @@ class AppRunJobsViewSet(viewsets.ViewSet):
             "task_category": "app_run",
         }
 
-        if frequency_type == "run_once":
+        if frequency_type == "run_now":
+            job = ScheduledJob(**job_args)
+            job.save()
+            job.schedule_now()
+
+        elif frequency_type == "run_once":
             job = ScheduledJob(**job_args)
             job.save()
 


### PR DESCRIPTION
## Goals
1. [X] UI Fix: Ensure manual job data entry is saved upon focus out.
2. [X] UI Fix: Prevent job input entries from being removed when data or other fields are updated.
3. [X] Ad-hoc job scheduling.

## Changes
1. [X] Modified `handleRowEditStop` in `InputDataTable.jsx` to automatically save manual data entries upon losing focus.
2. [X] Updated `appRunData` state in `AddAppRunScheduleModal` only if the selected application column fields match.
3. [X] Implemented changes to support immediate job execution (`Run Now`) in both the frontend and backend.

## Testing
- Tested end-to-end using various scenarios

## Reviewers
@ajhai and @vegito22