### PR TITLE
Use same langrocks-web-browser image in dev mode as in prod build

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
     env_file:
       - .env.dev
   runner:
-    image: langrocks-web-browser:latest
+    image: ghcr.io/langrocks/langrocks-web-browser:main
     env_file:
       - .env.dev
     ports:


### PR DESCRIPTION
I am facing some error while trying to run development setup on my local via command `docker compose -f docker/docker-compose.dev.yml --env-file docker/.env.dev up`

```sh
 ✘ runner Error pull access denied for langrocks-web-browser, repository does not exist or may require 'docker login': denied: request...               1.8s
```
I noticed that in the docker-composer.yml the runner is using a different image name, and was wondering if the image name in docker-compose.dev.yml was wrong. After making the changes in this PR, i was able to get past the error.
